### PR TITLE
Admin can toggle the ads status

### DIFF
--- a/src/api/ads.ts
+++ b/src/api/ads.ts
@@ -8,3 +8,15 @@ export const getAllAds = () => {
 export const getAllCompaniesAds = () => {
     return axios.get(`${baseUrl}/company-ads`);
 }
+
+export const getAllCompaniesAdsAdmin = () => {
+    return axios.get(`${baseUrl}/company-ads/admin`);
+}
+
+export const toggleAdActiveStatus = (id: string) => {
+    return axios.put(`${baseUrl}/company-ads/${id}/toggle-active`);
+}
+
+export const toggleAdvertActiveStatus = (id: string) => {
+    return axios.put(`${baseUrl}/ads/${id}/toggle-active`);
+}

--- a/src/components/Product/AddingOtherShopsModel.tsx
+++ b/src/components/Product/AddingOtherShopsModel.tsx
@@ -39,7 +39,7 @@ const AddOtherShopsModal: React.FC<ModalProps> = ({
   useEffect(() => {
     const fetchShops = async () => {
       try {
-        const { data } = await fetchAllShops();
+        const data = await fetchAllShops();
         setAllShops(data);
       } catch (error) {
         console.error('Failed to fetch shops:', error);

--- a/src/components/dashboard/ads/AdsPage.tsx
+++ b/src/components/dashboard/ads/AdsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getAllCompaniesAds } from '../../../api/ads';
+import { getAllCompaniesAdsAdmin, toggleAdActiveStatus } from '../../../api/ads';
 import { baseUrl } from '../../../api';
 import axios from 'axios';
 import { 
@@ -13,7 +13,7 @@ import {
   Space,
   message,
 } from 'antd';
-import { Delete } from 'lucide-react';
+import { MdDelete, MdSync } from 'react-icons/md';
 
 const { TabPane } = Tabs;
 
@@ -25,6 +25,7 @@ interface ICompanyAds {
   name: string;
   url: string;
   title: string;
+  active: Boolean;
   createdAt: string;
 }
 
@@ -42,7 +43,7 @@ const AdsManagementPage: React.FC = () => {
   
     useEffect(() => {
         const fetchAds = async () => {
-        const response = await getAllCompaniesAds();
+        const response = await getAllCompaniesAdsAdmin();
         setCompanyAds(response?.data?.advertisements);
         };
         fetchAds();
@@ -74,6 +75,14 @@ const AdsManagementPage: React.FC = () => {
       key: 'url',
     },
     {
+      title: 'Active',
+      dataIndex: 'active',
+      key: 'active',
+      render: (active: boolean) => (
+        <span>{active ? 'Yes' : 'No'}</span>
+      ),
+    },
+    {
       title: 'Created At',
       dataIndex: 'createdAt',
       key: 'createdAt',
@@ -92,7 +101,11 @@ const AdsManagementPage: React.FC = () => {
               () => {
                 handleDelete(record._id);
               }
-            } danger icon={<Delete />} />
+            } danger icon={<MdDelete />} />
+        <Button
+          onClick={() => handleToggleAdActiveStatus(record._id)}
+          icon={<MdSync />}
+        />
         </Space>
       ),
     },
@@ -119,6 +132,16 @@ const AdsManagementPage: React.FC = () => {
       message.success('Ad deleted successfully');
     } catch (error) {
       message.error('Failed to delete ad');
+    }
+  };
+  const handleToggleAdActiveStatus = async (id: string) => {
+    try {
+      await toggleAdActiveStatus(id);
+      message.success('Ad active status toggled successfully');
+      const response = await getAllCompaniesAdsAdmin();
+      setCompanyAds(response?.data?.advertisements);
+    } catch (error) {
+      message.error('Failed to toggle ad active status');
     }
   };
   const handleModalSubmit = async () => {

--- a/src/components/dashboard/bunnerAds/bunnerAds.tsx
+++ b/src/components/dashboard/bunnerAds/bunnerAds.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Table, Button, message } from 'antd';
+import { Table, Button, message, Space } from 'antd';
 import axios from 'axios';
 import AdUploadForm from './AdUploadForm';
 import { baseUrl } from '../../../api';
+import { toggleAdvertActiveStatus } from '../../../api/ads';
+import { MdDelete, MdSync } from 'react-icons/md';
 
 const AdvertisementList: React.FC = () => {
   const [ads, setAds] = useState([]);
@@ -12,7 +14,7 @@ const AdvertisementList: React.FC = () => {
   const fetchAds = async () => {
     setLoading(true);
     try {
-      const response = await axios.get(`${baseUrl}/ads`);
+      const response = await axios.get(`${baseUrl}/ads/admin`);
       setAds(response.data.advertisements);
     } catch (error) {
       message.error('Failed to fetch advertisements');
@@ -20,6 +22,16 @@ const AdvertisementList: React.FC = () => {
       setLoading(false);
     }
   };
+
+  const handleToggleAdvertActiveStatus = async (id: string) => {
+      try {
+        await toggleAdvertActiveStatus(id);
+        fetchAds();
+        message.success('Ad active status toggled successfully');
+      } catch (error) {
+        message.error('Failed to toggle ad active status');
+      }
+    };
 
   const deleteAd = async (id: string) => {
     try {
@@ -35,14 +47,22 @@ const AdvertisementList: React.FC = () => {
     { title: 'Title', dataIndex: 'title', key: 'title' },
     { title: 'Description', dataIndex: 'description', key: 'description' },
     { title: 'Ad Type', dataIndex: 'ad_type', key: 'ad_type' },
+    { title: 'Active', dataIndex: 'active', key: 'active', render: (active: boolean) => (
+      <span>{active ? 'Yes' : 'No'}</span>
+    ), },
     { title: 'Actions', key: 'actions', render: (_: any, record: any) => (
-     
-        <Button 
-        onClick={
-            () => {
-                deleteAd(record._id);
-            }
-        } danger>Delete</Button>
+        <Space>
+          <Button 
+          onClick={
+              () => {
+                  deleteAd(record._id);
+              }
+          } danger icon={<MdDelete />}/>
+        <Button
+          onClick={() => handleToggleAdvertActiveStatus(record._id)}
+          icon={<MdSync />}
+        />
+        </Space>
     ) },
   ];
 

--- a/src/components/home/HomeNav.tsx
+++ b/src/components/home/HomeNav.tsx
@@ -129,7 +129,7 @@ const lastPart = urlParts[urlParts.length - 1];
       )}
       <Dropdown overlay={menu} className='mt-1'>
         <Button>
-          <UserOutlined className='test text-white' />
+          <UserOutlined className='test text-black' />
         </Button>
       </Dropdown>
     </nav>


### PR DESCRIPTION
This PR enhances admin control over advertisements by introducing the ability to disable ads without deleting them. Disabled ads will no longer appear on the home page, and the admin can re-enable them at any time. This feature provides greater flexibility in managing ad visibility.